### PR TITLE
adjust x axis when content changes

### DIFF
--- a/addon/components/time-tree.js
+++ b/addon/components/time-tree.js
@@ -251,7 +251,12 @@ const TimeTreeComponent = Ember.Component.extend({
   },
 
   drawAxis() {
-    this.get('svg').select('.x.axis').call(this.get('xAxis'));
+      let labelsWidth = this.get('labelsWidth');
+      let contentHeight = this.get('contentHeight');
+      let axisPosition = this.get('axisPosition');
+      let axisTop = axisPosition === 'top' ? axisHeight : contentHeight;
+    this.get('svg').select('.x.axis').call(this.get('xAxis'))
+        .attr('transform', 'translate(' + labelsWidth + ',' + axisTop + ')');
   },
 
   // This function is passed to d3, it's not called as a member of the View


### PR DESCRIPTION
Previous code wasn't allowing the x axis to be repositioned when content changed (as in a promise resolving causing the tree to redraw).
